### PR TITLE
Allow custom APP_KEY

### DIFF
--- a/tests/test_simple_renderer.py
+++ b/tests/test_simple_renderer.py
@@ -152,7 +152,8 @@ class TestSimple(unittest.TestCase):
                 yield from func(req)
 
             self.assertEqual("Template engine is not initialized, "
-                             "call aiohttp_jinja2.setup() first",
+                             "call aiohttp_jinja2.setup(app_key={}) first"
+                             "".format(aiohttp_jinja2.APP_KEY),
                              ctx.exception.text)
 
         self.loop.run_until_complete(go())


### PR DESCRIPTION
This allows to have multiple jinja2 template environs for the same app,
when you need to apply different rendering context against different 
targets.