### PR TITLE
Add MANIFEST.in to avoid FileNotFoundError during installation

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,3 @@
+include CHANGES.txt
+include LICENSE
+include README.rst


### PR DESCRIPTION
Hi,

I've this error with aiohttp_jinja2 during automatic testing of FrameworkBenchmarks: 

> FileNotFoundError: [Errno 2] No such file or directory: '/tmp/pip-build-ocuet_n0/aiohttp-jinja2/CHANGES.txt'

More details: https://travis-ci.org/TechEmpower/FrameworkBenchmarks/jobs/64795101#L1679

If I understand correctly, it's because CHANGES.txt isn't included in https://pypi.python.org/packages/source/a/aiohttp_jinja2/aiohttp_jinja2-0.4.2.tar.gz#md5=64ea1917c255d19704334ada06398360

This pull request should fix this issue, at least on my computer.

BTW, if you should publish a new version after the merge, it will be useful to me ;-)