### PR TITLE
Check context's type and return context if it is not a dict

### DIFF
--- a/aiohttp_jinja2/__init__.py
+++ b/aiohttp_jinja2/__init__.py
@@ -80,7 +80,7 @@ def template(template_name, *, app_key=APP_KEY, encoding='utf-8', status=200):
             else:
                 coro = asyncio.coroutine(func)
             context = yield from coro(*args)
-            if isinstance(context, web.Response):
+            if isinstance(context, web.StreamResponse):
                 return context
             
             request = args[-1]

--- a/aiohttp_jinja2/__init__.py
+++ b/aiohttp_jinja2/__init__.py
@@ -80,7 +80,7 @@ def template(template_name, *, app_key=APP_KEY, encoding='utf-8', status=200):
             else:
                 coro = asyncio.coroutine(func)
             context = yield from coro(*args)
-            if not isinstance(context, dict):
+            if isinstance(context, web.Response):
                 return context
             
             request = args[-1]

--- a/aiohttp_jinja2/__init__.py
+++ b/aiohttp_jinja2/__init__.py
@@ -80,6 +80,9 @@ def template(template_name, *, app_key=APP_KEY, encoding='utf-8', status=200):
             else:
                 coro = asyncio.coroutine(func)
             context = yield from coro(*args)
+            if not isinstance(context, dict):
+                return context
+            
             request = args[-1]
             response = render_template(template_name, request, context,
                                        app_key=app_key, encoding=encoding)

--- a/tests/test_simple_renderer.py
+++ b/tests/test_simple_renderer.py
@@ -375,3 +375,43 @@ class TestSimple(unittest.TestCase):
             self.addCleanup(srv.close)
 
         self.loop.run_until_complete(go())
+
+    def test_context_is_response(self):
+
+        @aiohttp_jinja2.template('tmpl.jinja2')
+        def func(request):
+            return aiohttp.web_exceptions.HTTPFound('/redirect')
+
+        @aiohttp_jinja2.template('tmpl.jinja2')
+        def redirect_func(request):
+            return aiohttp_jinja2.render_template(
+                'tmpl.jinja2', request,
+                {'head': 'HEAD', 'text': 'text'})
+
+        @asyncio.coroutine
+        def go():
+            app = web.Application(loop=self.loop)
+            aiohttp_jinja2.setup(app, loader=jinja2.DictLoader(
+                {'tmpl.jinja2':
+                 "<html><body><h1>{{head}}</h1>{{text}}</body></html>"}))
+
+            app.router.add_route('GET', '/', func)
+            app.router.add_route('GET', '/redirect', redirect_func)
+
+            port = self.find_unused_port()
+            handler = app.make_handler()
+            srv = yield from self.loop.create_server(
+                handler, '127.0.0.1', port)
+            url = "http://127.0.0.1:{}/".format(port)
+
+            resp = yield from aiohttp.request('GET', url, loop=self.loop)
+            self.assertEqual(200, resp.status)
+            txt = yield from resp.text()
+            self.assertEqual('<html><body><h1>HEAD</h1>text</body></html>',
+                             txt)
+
+            yield from handler.finish_connections()
+            srv.close()
+            self.addCleanup(srv.close)
+
+        self.loop.run_until_complete(go())

--- a/tests/test_simple_renderer.py
+++ b/tests/test_simple_renderer.py
@@ -384,9 +384,7 @@ class TestSimple(unittest.TestCase):
 
         @aiohttp_jinja2.template('tmpl.jinja2')
         def redirect_func(request):
-            return aiohttp_jinja2.render_template(
-                'tmpl.jinja2', request,
-                {'head': 'HEAD', 'text': 'text'})
+            return {'head': 'HEAD', 'text': 'text'}
 
         @asyncio.coroutine
         def go():


### PR DESCRIPTION
    @aiohttp_jinja2.template('index.jinja2')
    def check(request):
        param = request.match_info['param']
        if param == 'first':
            # success
            return dict(text='First case')
        elif param == 'second':
            # success
            return dict(text='Second case', user='Tark')
        elif param == 'another':
            # fail!
            # context should be mapping, not <class 'aiohttp.web_reqrep.Response'>
            return aiohttp_jinja2.render_template(
                'another.jinja2', request=request, context=dict(user='Tark', sum=0))
        elif param == 'json':
            s = dict(text='JSON', user='Tark')
            # fail!
            # context should be mapping, not <class 'aiohttp.web_reqrep.Response'>
            return web.Response(body=bytes(json.dumps(s), encoding='utf-8'),
                                content_type='application/json')
        elif param == 'redirect':
            # fail!
            # context should be mapping, not <class 'aiohttp.web_exceptions.HTTPFound'>
            return HTTPFound('http://google.com')
        return dict(text='Hello!')

It can be in a real-world project. @aiohttp_jinja2.template has been used for a few lines shorter code.
But with checking context's type in `template` decorator it will work and http://stackoverflow.com/questions/29322753/aiohttp-and-aiohttp-jinja2-response-error will never be asked.