### PR TITLE
Adds ability to decorate class based views (available in aiohttp 0.20)

### DIFF
--- a/aiohttp_jinja2/__init__.py
+++ b/aiohttp_jinja2/__init__.py
@@ -22,7 +22,7 @@ def setup(app, *args, app_key=APP_KEY, context_processors=(), **kwargs):
         app[APP_CONTEXT_PROCESSORS_KEY] = context_processors
         app.middlewares.append(context_processors_middleware)
 
-    def url(__aiohttp_jinjs2_route_name,  **kwargs):
+    def url(__aiohttp_jinjs2_route_name, **kwargs):
         return app.router[__aiohttp_jinjs2_route_name].url(**kwargs)
 
     env.globals['url'] = url
@@ -86,7 +86,12 @@ def template(template_name, *, app_key=APP_KEY, encoding='utf-8', status=200):
             if isinstance(context, web.StreamResponse):
                 return context
 
-            request = args[-1]
+            # Supports class based views see web.View
+            if isinstance(args[0], web.View):
+                request = args[0].request
+            else:
+                request = args[-1]
+
             response = render_template(template_name, request, context,
                                        app_key=app_key, encoding=encoding)
             response.set_status(status)

--- a/aiohttp_jinja2/__init__.py
+++ b/aiohttp_jinja2/__init__.py
@@ -5,7 +5,7 @@ from collections import Mapping
 from aiohttp import web
 
 
-__version__ = '0.6.2'
+__version__ = '0.6.3'
 
 __all__ = ('setup', 'get_env', 'render_template', 'template')
 

--- a/aiohttp_jinja2/__init__.py
+++ b/aiohttp_jinja2/__init__.py
@@ -3,6 +3,7 @@ import functools
 import jinja2
 from collections import Mapping
 from aiohttp import web
+from aiohttp.abc import AbstractView
 
 
 __version__ = '0.6.3'
@@ -87,7 +88,7 @@ def template(template_name, *, app_key=APP_KEY, encoding='utf-8', status=200):
                 return context
 
             # Supports class based views see web.View
-            if isinstance(args[0], web.View):
+            if isinstance(args[0], AbstractView):
                 request = args[0].request
             else:
                 request = args[-1]

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 import codecs
-from setuptools import setup, find_packages
+from setuptools import setup
 import os
 import re
 
@@ -15,7 +15,7 @@ with codecs.open(os.path.join(os.path.abspath(os.path.dirname(
 def read(f):
     return open(os.path.join(os.path.dirname(__file__), f)).read().strip()
 
-install_requires = ['aiohttp>=0.18', 'jinja2>=2.7']
+install_requires = ['aiohttp>=0.20', 'jinja2>=2.7']
 tests_require = install_requires + ['nose']
 
 


### PR DESCRIPTION
* Adds support for decorating [class based views](https://aiohttp.readthedocs.org/en/stable/web.html#class-based-views)
* Removes unused import

Allows:

```
import os

from aiohttp import web
import aiohttp_jinja2
import jinja2


class IndexView(web.View):
    @aiohttp_jinja2.template('index.html')
    async def get(self):
        return {}


app = web.Application()
app.router.add_route('*', '/', IndexView)

aiohttp_jinja2.setup(app, loader=jinja2.FileSystemLoader(os.path.join(os.path.dirname(__file__), 'templates')))
```

Whereas before it would yield an error that there is no app on request (since it was getting a subclass of the web.View)