### PR TITLE
Convert readthedocs link for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -6,7 +6,7 @@ jinja2_ template renderer for `aiohttp.web`__.
 
 .. _jinja2: http://jinja.pocoo.org
 
-.. _aiohttp_web: http://aiohttp.readthedocs.org/en/latest/web.html
+.. _aiohttp_web: https://aiohttp.readthedocs.io/en/latest/web.html
 
 __ aiohttp_web_
 
@@ -31,7 +31,7 @@ Using the function based web handlers::
         return {'name': 'Andrew', 'surname': 'Svetlov'}
 
 Or for `Class Based Views
-<https://aiohttp.readthedocs.org/en/stable/web.html#class-based-views>`::
+<https://aiohttp.readthedocs.io/en/stable/web.html#class-based-views>`::
 
     class Handler(web.View):
         @aiohttp_jinja2.template('tmpl.jinja2')

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -305,5 +305,5 @@ texinfo_documents = [
 
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {'http://docs.python.org/3': None,
-                       'http://aiohttp.readthedocs.org/en/stable': None,
+                       'https://aiohttp.readthedocs.io/en/stable': None,
                        'http://jinja2.pocoo.org/docs/dev': None}


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.