### PR TITLE
Add ability to render template without context

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -10,6 +10,21 @@ jinja2_ template renderer for `aiohttp.web`__.
 
 __ aiohttp_web_
 
+Installation
+------------
+Install from PyPI::
+
+    pip install aiohttp-jinja2
+
+
+Developing
+----------
+
+Install requirement and launch tests::
+
+    pip install -r requirements-dev.txt
+    py.test tests
+
 
 Usage
 -----

--- a/aiohttp_jinja2/__init__.py
+++ b/aiohttp_jinja2/__init__.py
@@ -66,6 +66,8 @@ def render_string(template_name, request, context, *, app_key=APP_KEY):
 def render_template(template_name, request, context, *,
                     app_key=APP_KEY, encoding='utf-8'):
     response = web.Response()
+    if context is None:
+        context = {}
     text = render_string(template_name, request, context, app_key=app_key)
     response.content_type = 'text/html'
     response.charset = encoding


### PR DESCRIPTION
## Rationale 
It's very useful sometimes just render plain html without any context provided and it's very convenient to write

```
@aiohttp_jinja2.template('faq.html')
def faq(request):
    pass
```

## Changes
* Handle case when `context is None`
* Remove code duplication in tests creating common helper method

@jettify 